### PR TITLE
Problem deploying to Heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ build
 
 # env
 config.js
+
+# Heroku Local Envvars
+.env

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run start
+web: npm run postinstall && npm run start

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/rockchalkwushock/name-later#readme",
   "dependencies": {
-    "bcrypt": "^0.8.7",
+    "bcrypt": "^1.0.0",
     "body-parser": "^1.15.2",
     "chai": "^3.5.0",
     "enzyme": "^2.6.0",
@@ -53,12 +53,7 @@
       "es2015",
       "react",
       "stage-0"
-    ],
-    "env": {
-      "presets": [
-        "react-hmre"
-      ]
-    }
+    ]
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
@@ -67,7 +62,6 @@
     "babel-loader": "^6.2.8",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
-    "babel-preset-react-hmre": "^1.1.1",
     "babel-preset-stage-0": "^6.16.0",
     "babel-register": "^6.18.0",
     "chai": "^3.5.0",
@@ -76,8 +70,6 @@
     "mocha": "^3.2.0",
     "nodemon": "^1.11.0",
     "react-addons-test-utils": "^15.4.1",
-    "webpack": "^1.13.3",
-    "webpack-dev-middleware": "^1.8.4",
-    "webpack-hot-middleware": "^2.13.2"
+    "webpack": "^1.13.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "src/client/index.jsx",
   "scripts": {
     "test": "mocha --compilers js:babel-register test/**/*.js*",
-    "start": "npm run build && npm run server",
+    "postinstall": "npm run build",
+    "start": "babel-node src/server/index.js",
     "dev": "npm run build && nodemon --exec babel-node src/server/index.js",
-    "server": "babel-node src/server/index.js",
     "mkdir": "mkdir -p build",
     "build": "npm run clean && npm run mkdir && npm run build:html && npm run build:js",
     "watch": "npm run watch:html & npm run watch:js",
@@ -27,7 +27,7 @@
     "express"
   ],
   "engines": {
-    "node": "4.1.1"
+    "node": "7.1.0"
   },
   "author": "Cody Brunner <rockchalkwushock@icloud.com>",
   "license": "ISC",
@@ -36,6 +36,13 @@
   },
   "homepage": "https://github.com/rockchalkwushock/name-later#readme",
   "dependencies": {
+    "babel-cli": "^6.18.0",
+    "babel-core": "^6.18.2",
+    "babel-loader": "^6.2.9",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-0": "^6.16.0",
+    "babel-register": "^6.18.0",
     "bcrypt": "^1.0.0",
     "body-parser": "^1.15.2",
     "chai": "^3.5.0",
@@ -46,7 +53,8 @@
     "passport-local": "^1.0.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
-    "validator": "^6.2.0"
+    "validator": "^6.2.0",
+    "webpack": "^1.14.0"
   },
   "babel": {
     "presets": [
@@ -56,20 +64,12 @@
     ]
   },
   "devDependencies": {
-    "babel-cli": "^6.18.0",
-    "babel-core": "^6.18.2",
     "babel-eslint": "^7.1.1",
-    "babel-loader": "^6.2.8",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "babel-register": "^6.18.0",
     "chai": "^3.5.0",
     "eslint": "^3.11.1",
     "eslint-config-rallycoding": "^3.1.0",
     "mocha": "^3.2.0",
     "nodemon": "^1.11.0",
-    "react-addons-test-utils": "^15.4.1",
-    "webpack": "^1.13.3"
+    "react-addons-test-utils": "^15.4.1"
   }
 }


### PR DESCRIPTION
This is my first time getting webpack and heroku to play nice.

I've tried moving packages to the `dependencies` instead of `dev-dependencies`, but continue to get errors of varying type. The current setup has the below error log from Heroku:

NOTE: I have gone ahead and applied the following to Heroku (noted this is not a good practice just, as heroku installs ALL dependencies which can slow down the application and cause other issues. Right now I'm just trying to get it to deploy).

`heroku config:set NPM_CONFIG_PRODUCTION=false`

```
Error: Couldn't find preset "es2015" relative to directory "/app"
     at /app/node_modules/babel-core/lib/transformation/file/options/option-manager.js:299:19
     at Array.map (native)
     at OptionManager.resolvePresets (/app/node_modules/babel-core/lib/transformation/file/options/option-manager.js:270:20)
     at OptionManager.mergePresets (/app/node_modules/babel-core/lib/transformation/file/options/option-manager.js:259:10)
     at OptionManager.mergeOptions (/app/node_modules/babel-core/lib/transformation/file/options/option-manager.js:244:14)
     at OptionManager.init (/app/node_modules/babel-core/lib/transformation/file/options/option-manager.js:374:12)
     at compile (/app/node_modules/babel-register/lib/node.js:103:45)
     at loader (/app/node_modules/babel-register/lib/node.js:144:14)
     at Object.require.extensions.(anonymous function) [as .js] (/app/node_modules/babel-register/lib/node.js:154:7)
     at Module.load (module.js:487:32)
```

I have `babel-preset-es2015` installed as a `devDependency` and in loo of a `.bablerc` the presets are listed in the `package.json`. The presets being used are also noted in the respected loader in the webpack. Beginning to scratch my head on this one as I've been researching it for a few hours now with no success. 